### PR TITLE
FIx unicode decode error

### DIFF
--- a/src/camtasia/project.py
+++ b/src/camtasia/project.py
@@ -22,7 +22,7 @@ class Project:
 
     def __init__(self, file_path):
         self._file_path = file_path
-        self._data = json.loads(self._project_file.read_text())
+        self._data = json.loads(self._project_file.read_text(encoding='utf-8'))
 
     @property
     def file_path(self) -> Path:


### PR DESCRIPTION
camtasia.load_project fails for files containing unicode characters. `encoding='utf-8' `  is a better default position to the standard 1512 encoding that pathlib.py defaults to.